### PR TITLE
Resolve 19 clippy lints and enforce clippy in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+          components: clippy
 
       - name: Install dependencies (Ubuntu only)
         if: matrix.platform == 'ubuntu-22.04'
@@ -124,6 +125,15 @@ jobs:
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: cd src-tauri && cargo generate-lockfile
+
+      - name: Run Clippy
+        working-directory: src-tauri
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: ${{ steps.vnas-check.outputs.vnas_available == 'true' }}
+        run: >-
+          cargo clippy --all-targets
+          ${{ steps.vnas-check.outputs.vnas_available == 'true' && '--features vnas' || '' }}
+          -- -D warnings
 
       - name: Build Tauri app (with signing)
         if: steps.signing-check.outputs.signing_available == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+          components: clippy
 
       - name: Install dependencies (Ubuntu only)
         if: matrix.platform == 'ubuntu-22.04'
@@ -148,6 +149,18 @@ jobs:
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: cd src-tauri && cargo generate-lockfile
+
+      - name: Build frontend (for clippy)
+        run: pnpm run vite:build
+
+      - name: Run Clippy
+        working-directory: src-tauri
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: ${{ steps.vnas-check.outputs.vnas_available == 'true' }}
+        run: >-
+          cargo clippy --all-targets
+          ${{ steps.vnas-check.outputs.vnas_available == 'true' && '--features vnas' || '' }}
+          -- -D warnings
 
       - name: Build Tauri app (with signing)
         if: steps.signing-check.outputs.signing_available == 'true'

--- a/scripts/shipping/build/check.js
+++ b/scripts/shipping/build/check.js
@@ -164,56 +164,82 @@ function runCommandWithOutput(command, args, options = {}) {
 }
 
 /**
- * Run Cargo check for Rust backend (both with and without vnas feature)
+ * Run Cargo check + Clippy for Rust backend (both with and without vnas feature)
  */
 async function runCargoCheck(quiet = false) {
   logHeader('Cargo (Rust)');
 
-  // Use RUSTFLAGS to deny warnings
+  // Use RUSTFLAGS to deny rustc warnings. Clippy also reads this, so clippy
+  // lints at deny level in Cargo.toml's [lints.clippy] will fail the build.
   const env = { ...process.env, RUSTFLAGS: '-D warnings' };
-  const baseArgs = ['check'];
-  if (quiet) baseArgs.push('--quiet');
+  const checkArgs = ['check'];
+  if (quiet) checkArgs.push('--quiet');
+  const clippyArgs = ['clippy', '--all-targets'];
+  if (quiet) clippyArgs.push('--quiet');
+  clippyArgs.push('--', '-D', 'warnings');
+
+  const cargoOpts = { cwd: join(ROOT_DIR, 'src-tauri'), env };
 
   // Check without vnas feature (public build)
   log('Checking without vnas feature...', colors.blue);
-  const resultWithout = await runCommand('cargo', baseArgs, {
-    cwd: join(ROOT_DIR, 'src-tauri'),
-    env,
-  });
-
-  if (!resultWithout.success) {
+  const resultCheckWithout = await runCommand('cargo', checkArgs, cargoOpts);
+  if (!resultCheckWithout.success) {
     logError('Cargo check (without vnas) found errors or warnings');
-    return resultWithout;
+    return resultCheckWithout;
   }
   logSuccess('Cargo check (without vnas) passed');
+
+  console.log();
+  log('Running clippy (without vnas)...', colors.blue);
+  const resultClippyWithout = await runCommand('cargo', clippyArgs, cargoOpts);
+  if (!resultClippyWithout.success) {
+    logError('Cargo clippy (without vnas) found lints');
+    return resultClippyWithout;
+  }
+  logSuccess('Cargo clippy (without vnas) passed');
 
   // Check with vnas feature (private build)
   console.log();
   log('Checking with vnas feature...', colors.blue);
-  const argsWithVnas = [...baseArgs, '--features', 'vnas'];
-  const resultWith = await runCommandWithOutput('cargo', argsWithVnas, {
-    cwd: join(ROOT_DIR, 'src-tauri'),
-    env,
-  });
+  const checkArgsWithVnas = [...checkArgs, '--features', 'vnas'];
+  const resultCheckWith = await runCommandWithOutput('cargo', checkArgsWithVnas, cargoOpts);
 
-  if (resultWith.success) {
-    logSuccess('Cargo check (with vnas) passed');
-    return { success: true, code: 0 };
+  if (!resultCheckWith.success) {
+    // Check if failure is due to missing private repo access
+    const output = resultCheckWith.stdout + resultCheckWith.stderr;
+    if (output.includes('towercab-3d-vnas') &&
+        (output.includes('failed to authenticate') ||
+         output.includes('could not read') ||
+         output.includes('failed to fetch'))) {
+      logWarning('Cargo check (with vnas) skipped - no access to private repo');
+      log('  This is expected for public contributors', colors.yellow);
+      return { success: true, code: 0 }; // Don't fail the build
+    }
+    logError('Cargo check (with vnas) found errors or warnings');
+    return { success: false, code: 1 };
   }
+  logSuccess('Cargo check (with vnas) passed');
 
-  // Check if failure is due to missing private repo access
-  const output = resultWith.stdout + resultWith.stderr;
-  if (output.includes('towercab-3d-vnas') &&
-      (output.includes('failed to authenticate') ||
-       output.includes('could not read') ||
-       output.includes('failed to fetch'))) {
-    logWarning('Cargo check (with vnas) skipped - no access to private repo');
-    log('  This is expected for public contributors', colors.yellow);
-    return { success: true, code: 0 }; // Don't fail the build
+  console.log();
+  log('Running clippy (with vnas)...', colors.blue);
+  const clippyArgsWithVnas = [
+    'clippy',
+    '--all-targets',
+    '--features',
+    'vnas',
+    ...(quiet ? ['--quiet'] : []),
+    '--',
+    '-D',
+    'warnings',
+  ];
+  const resultClippyWith = await runCommand('cargo', clippyArgsWithVnas, cargoOpts);
+  if (!resultClippyWith.success) {
+    logError('Cargo clippy (with vnas) found lints');
+    return resultClippyWith;
   }
+  logSuccess('Cargo clippy (with vnas) passed');
 
-  logError('Cargo check (with vnas) found errors or warnings');
-  return { success: false, code: 1 };
+  return { success: true, code: 0 };
 }
 
 /**

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,3 +63,13 @@ windows-sys = { version = "0.61", features = ["Win32_System_JobObjects", "Win32_
 # RUSTFLAGS="-D warnings" that needs no env plumbing in workflows.
 [lints.rust]
 warnings = "deny"
+
+# Treat clippy's default lint groups as errors. Only applied when `cargo clippy`
+# is explicitly invoked (check.js --rust, CI); it has no effect on cargo check
+# or cargo build. Keep opinionated groups (pedantic/nursery/restriction) opt-in.
+[lints.clippy]
+correctness = { level = "deny", priority = -1 }
+suspicious = { level = "deny", priority = -1 }
+complexity = { level = "deny", priority = -1 }
+perf = { level = "deny", priority = -1 }
+style = { level = "deny", priority = -1 }

--- a/src-tauri/src/files.rs
+++ b/src-tauri/src/files.rs
@@ -7,7 +7,7 @@
 //! - Cache directory management
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri_plugin_dialog::DialogExt;
 
 use crate::normalize_path_string;
@@ -175,7 +175,7 @@ pub fn clear_cache_directory(path: String) -> Result<(), String> {
 // =============================================================================
 
 /// Check if a directory path is writable
-pub fn is_path_writable(path: &PathBuf) -> bool {
+pub fn is_path_writable(path: &Path) -> bool {
     // Try to create a test file
     let test_file = path.join(".write_test");
     match fs::write(&test_file, "test") {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,7 +14,7 @@
 
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
 use std::sync::Mutex;
 
@@ -215,11 +215,11 @@ static OBSERVATIONS_TX: Mutex<Option<broadcast::Sender<server::ObservationMessag
 // =============================================================================
 
 /// Normalize path string by removing Windows extended path prefix (\\?\)
-pub fn normalize_path_string(path: &PathBuf) -> String {
+pub fn normalize_path_string(path: &Path) -> String {
     let s = path.to_string_lossy().to_string();
     // Remove \\?\ prefix that Windows uses for long paths
-    if s.starts_with(r"\\?\") {
-        s[4..].to_string()
+    if let Some(stripped) = s.strip_prefix(r"\\?\") {
+        stripped.to_string()
     } else {
         s
     }
@@ -234,8 +234,8 @@ pub fn to_extended_length_path(path: &str) -> String {
         return path.to_string();
     }
     // UNC paths need different handling (\\server\share -> \\?\UNC\server\share)
-    if path.starts_with(r"\\") {
-        return format!(r"\\?\UNC\{}", &path[2..]);
+    if let Some(stripped) = path.strip_prefix(r"\\") {
+        return format!(r"\\?\UNC\{stripped}");
     }
     // Regular absolute paths (C:\... -> \\?\C:\...)
     if path.len() >= 2 && path.chars().nth(1) == Some(':') {
@@ -286,10 +286,11 @@ fn get_lan_ips() -> Vec<String> {
                     if let std::net::SocketAddr::V4(v4) = addr {
                         let ip = v4.ip().to_string();
                         // Skip loopback and link-local addresses
-                        if !ip.starts_with("127.") && !ip.starts_with("169.254.") {
-                            if !ips.contains(&ip) {
-                                ips.push(ip);
-                            }
+                        if !ip.starts_with("127.")
+                            && !ip.starts_with("169.254.")
+                            && !ips.contains(&ip)
+                        {
+                            ips.push(ip);
                         }
                     }
                 }

--- a/src-tauri/src/mods.rs
+++ b/src-tauri/src/mods.rs
@@ -8,7 +8,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::normalize_path_string;
 
@@ -428,8 +428,8 @@ fn discover_mods_recursive(
 
 /// Parse a manifest.json to determine mod type and extract discovery info
 fn parse_manifest_for_discovery(
-    mod_dir: &PathBuf,
-    mods_root: &PathBuf,
+    mod_dir: &Path,
+    mods_root: &Path,
 ) -> Result<DiscoveredMod, String> {
     let manifest_path = mod_dir.join("manifest.json");
     let content = fs::read_to_string(&manifest_path)
@@ -467,8 +467,8 @@ fn parse_manifest_for_discovery(
 }
 
 /// Check if a directory is inside a git repo and get the repo folder name
-fn find_git_repo_info(dir: &PathBuf, mods_root: &PathBuf) -> (bool, Option<String>) {
-    let mut current = dir.clone();
+fn find_git_repo_info(dir: &Path, mods_root: &Path) -> (bool, Option<String>) {
+    let mut current = dir.to_path_buf();
 
     while current.starts_with(mods_root) && current != *mods_root {
         let git_dir = current.join(".git");

--- a/src-tauri/src/msfs.rs
+++ b/src-tauri/src/msfs.rs
@@ -152,21 +152,17 @@ fn parse_aircraft_cfg_unified(aircraft_dir: &std::path::Path) -> ParsedAircraftC
         let lower = trimmed.to_lowercase();
 
         // Parse [General] section - only need ICAO type designator
-        if in_general_section {
-            if lower.starts_with("icao_type_designator") {
-                if let Some(val) = extract_cfg_value_inline(trimmed) {
-                    result.icao_type = Some(val.to_uppercase());
-                }
+        if in_general_section && lower.starts_with("icao_type_designator") {
+            if let Some(val) = extract_cfg_value_inline(trimmed) {
+                result.icao_type = Some(val.to_uppercase());
             }
         }
 
         // Parse [VARIATION] section - base_container specifies the base model folder
-        if in_variation_section {
-            if lower.starts_with("base_container") {
-                if let Some(val) = extract_cfg_value_inline(trimmed) {
-                    // Store the raw value (e.g., "..\FSLTL_B77LF")
-                    result.base_container = Some(val);
-                }
+        if in_variation_section && lower.starts_with("base_container") {
+            if let Some(val) = extract_cfg_value_inline(trimmed) {
+                // Store the raw value (e.g., "..\FSLTL_B77LF")
+                result.base_container = Some(val);
             }
         }
 
@@ -577,10 +573,10 @@ fn parse_model_xml(xml_path: &std::path::Path) -> Option<String> {
                     }
                 }
 
-                if !model_file.is_empty() {
-                    if best_lod.is_none() || min_size > best_lod.as_ref().unwrap().0 {
-                        best_lod = Some((min_size, model_file));
-                    }
+                if !model_file.is_empty()
+                    && (best_lod.is_none() || min_size > best_lod.as_ref().unwrap().0)
+                {
+                    best_lod = Some((min_size, model_file));
                 }
             }
             Ok(Event::Eof) => break,
@@ -985,7 +981,7 @@ fn list_models_unified(
 
         if !liveries.is_empty() {
             // Scan texture directories ONCE for this folder (not per-livery!)
-            let mut folder_texture_dirs: Vec<String> = fs::read_dir(&aircraft_dir)
+            let mut folder_texture_dirs: Vec<String> = fs::read_dir(aircraft_dir)
                 .ok()
                 .into_iter()
                 .flatten()
@@ -1042,7 +1038,7 @@ fn list_models_unified(
                     source: config.source.to_string(),
                     model_name: livery.title.clone(),
                     folder_name: folder_name.clone(),
-                    aircraft_folder_path: normalize_path_string(&aircraft_dir),
+                    aircraft_folder_path: normalize_path_string(aircraft_dir),
                     gltf_path: gltf_path.clone(),
                     texture_dirs: livery_texture_dirs,
                     aircraft_type: aircraft_type.clone(),
@@ -1053,7 +1049,7 @@ fn list_models_unified(
         } else {
             // Fallback: No aircraft.cfg liveries found
             // Scan texture.* folders and create entries for each
-            let livery_folders: Vec<_> = fs::read_dir(&aircraft_dir)
+            let livery_folders: Vec<_> = fs::read_dir(aircraft_dir)
                 .ok()
                 .into_iter()
                 .flatten()
@@ -1088,7 +1084,7 @@ fn list_models_unified(
                         source: config.source.to_string(),
                         model_name,
                         folder_name: folder_name.clone(),
-                        aircraft_folder_path: normalize_path_string(&aircraft_dir),
+                        aircraft_folder_path: normalize_path_string(aircraft_dir),
                         gltf_path: gltf_path.clone(),
                         texture_dirs,
                         aircraft_type: aircraft_type.clone(),
@@ -1098,10 +1094,10 @@ fn list_models_unified(
                 }
             } else {
                 // No texture.* folders - create single entry with all textures
-                let all_texture_dirs = collect_texture_dirs(&aircraft_dir);
+                let all_texture_dirs = collect_texture_dirs(aircraft_dir);
 
                 // Try to get title from aircraft.cfg, fall back to folder name
-                let model_name = parse_aircraft_cfg_title(&aircraft_dir)
+                let model_name = parse_aircraft_cfg_title(aircraft_dir)
                     .unwrap_or_else(|| folder_name.clone());
 
                 // Try to extract airline from folder name (FSLTL_B738_AAL -> AAL)
@@ -1120,7 +1116,7 @@ fn list_models_unified(
                     source: config.source.to_string(),
                     model_name,
                     folder_name: folder_name.clone(),
-                    aircraft_folder_path: normalize_path_string(&aircraft_dir),
+                    aircraft_folder_path: normalize_path_string(aircraft_dir),
                     gltf_path: gltf_path.clone(),
                     texture_dirs: all_texture_dirs,
                     aircraft_type: aircraft_type.clone(),
@@ -1327,6 +1323,9 @@ pub async fn list_aig_models(
 /// - livery_title: Livery title from aircraft.cfg to convert (only this livery)
 /// - gltf_path: Explicit GLTF path (for AIG shared models where GLTF is in a different folder)
 /// - texture_dirs: Pre-computed texture directories from model indexing
+// Each argument is part of the Tauri IPC contract deserialized from the
+// frontend; grouping them into a struct would break that surface.
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn convert_msfs_model(
     app: tauri::AppHandle,
@@ -1390,8 +1389,8 @@ pub async fn convert_msfs_model(
     // Use --no-discovery mode: Rust has already resolved all paths via model.cfg parsing,
     // so we skip Python's discovery and pass all required data directly.
     // This ensures consistent behavior - Rust is the single source of truth for path resolution.
-    let use_no_discovery = gltf_path.as_ref().map_or(false, |p| !p.is_empty())
-        && texture_dirs.as_ref().map_or(false, |t| !t.is_empty())
+    let use_no_discovery = gltf_path.as_ref().is_some_and(|p| !p.is_empty())
+        && texture_dirs.as_ref().is_some_and(|t| !t.is_empty())
         && !livery_title.is_empty();
 
     if use_no_discovery {

--- a/src-tauri/src/vmr.rs
+++ b/src-tauri/src/vmr.rs
@@ -37,7 +37,7 @@ pub struct ParsedVmrRule {
 
 /// Parse a single VMR file using quick-xml
 fn parse_vmr_file(path: &std::path::Path) -> Vec<ParsedVmrRule> {
-    let source_path = normalize_path_string(&path.to_path_buf());
+    let source_path = normalize_path_string(path);
     let content = match fs::read_to_string(path) {
         Ok(c) => c,
         Err(e) => {


### PR DESCRIPTION
Stacked on #92. Base branch is `worktree-graceful-imagining-hartmanis`; rebase to `main` once that merges.

## Summary
- Fix every lint flagged by `cargo clippy --all-targets` on the Rust backend (19 issues across 5 files)
- Add `[lints.clippy]` in `src-tauri/Cargo.toml` with `correctness`, `suspicious`, `complexity`, `perf`, `style` denied (pedantic/nursery remain opt-in)
- Run `cargo clippy --all-targets -- -D warnings` in `check.js --rust` and in both CI workflows, so lints fail builds

## Lint breakdown

| Lint | Count | Fix approach |
|------|-------|--------------|
| `ptr_arg` | 3 | `&PathBuf` → `&Path` on 4 function signatures, plus removed an `&path.to_path_buf()` that fell out in vmr.rs |
| `collapsible_if` | 4 | Merge with `&&` in msfs.rs cfg parsing, msfs.rs LOD picker, lib.rs LAN IP filter |
| `needless_borrow` / `needless_borrows_for_generic_args` | 7 | Drop `&` on `aircraft_dir` uses — it is already `&PathBuf` from the for-loop binding |
| `unnecessary_map_or` | 2 | `map_or(false, …)` → `is_some_and(…)` in `convert_msfs_model` |
| `manual_strip` | 2 | `starts_with` + slice → `strip_prefix` in `normalize_path_string` and `to_extended_length_path` |
| `too_many_arguments` | 1 | Scoped `#[allow]` on `convert_msfs_model` — its argument list is the Tauri IPC surface; bundling into a struct would force a matching frontend change with no real benefit |

## CI changes
- Both workflows install the `clippy` component via `dtolnay/rust-toolchain@stable`
- A new `Run Clippy` step runs after the vnas/signing setup (so it lints the exact source that will be built) and before the Tauri build
- `release.yml` also gains an explicit `Build frontend (for clippy)` step since `tauri_build::build()` needs `../dist/` to exist

## Scope left out
- `clippy::pedantic`, `nursery`, `restriction` — these surface many stylistic lints with lots of subjective tradeoffs. If you want any of these later, it is a separate larger effort.

## Test plan
- [x] `cargo clippy --all-targets` passes locally (with and without `--features vnas`)
- [x] `cargo check --all-targets` still passes
- [x] `pnpm run check:rust` passes end-to-end (check + clippy, both feature sets)
- [x] Re-introducing a `manual_strip` violation makes `cargo clippy` exit non-zero — the gate bites
- [ ] CI runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)